### PR TITLE
Better error message for existing blockchain name

### DIFF
--- a/app/api/configuration_route.py
+++ b/app/api/configuration_route.py
@@ -162,8 +162,9 @@ class BlockchainExist(Resource):
     @config_ns.expect(blockchain_parser)
     @config_ns.doc(
         responses={
-            status.HTTP_400_BAD_REQUEST: "BAD REQUEST",
             status.HTTP_200_OK: "SUCCESS",
+            status.HTTP_400_BAD_REQUEST: "BAD REQUEST",
+            status.HTTP_409_CONFLICT: "CONFLICT",
         }
     )
     def get(self):
@@ -178,14 +179,17 @@ class BlockchainExist(Resource):
             raise ValueError("The blockchain name can't be empty!")
 
         blockchain_name = blockchain_name.strip()
-        blockchain_status = "Blockchain name already exists!"
 
         existing_blockchains = cc.get_blockchains()
 
-        if blockchain_name not in existing_blockchains:
+        if blockchain_name in existing_blockchains:
+            blockchain_status = "Blockchain name already exists!"
+            
+            return {"status": blockchain_status}, status.HTTP_409_CONFLICT
+        else:
             blockchain_status = "Valid blockchain name"
 
-        return {"status": blockchain_status}, status.HTTP_200_OK
+            return {"status": blockchain_status}, status.HTTP_200_OK
 
 
 @config_ns.route("/get_blockchains")

--- a/app/api/configuration_route.py
+++ b/app/api/configuration_route.py
@@ -169,7 +169,7 @@ class BlockchainExist(Resource):
     )
     def get(self):
         """
-        Determines wheher the blockchain exists or not
+        Determines whether the blockchain exists or not
         """
         args = blockchain_parser.parse_args(strict=True)
 

--- a/app/api/configuration_route.py
+++ b/app/api/configuration_route.py
@@ -187,7 +187,7 @@ class BlockchainExist(Resource):
             
             return {"status": blockchain_status}, status.HTTP_409_CONFLICT
         else:
-            blockchain_status = "Valid blockchain name"
+            blockchain_status = "The blockchain name is available"
 
             return {"status": blockchain_status}, status.HTTP_200_OK
 


### PR DESCRIPTION
It’s a very small change. The server now returns a `409 CONFLICT` if the provided blockchain name already exists.