### PR TITLE
fixed broken connect to admin node and add new node end point

### DIFF
--- a/app/api/node_route.py
+++ b/app/api/node_route.py
@@ -7,6 +7,7 @@ from flask_restplus import Namespace, Resource, reqparse, inputs, fields
 
 NEW_NODE_ADDRESS_FIELD_NAME = "newNodeAddress"
 ADMIN_NODE_ADDRESS_FIELD_NAME = "adminNodeAddress"
+BLOCKCHAIN_NAME_FIELD_NAME = "blockchainName"
 
 node_ns = Namespace("nodes", description="Nodes API")
 
@@ -47,6 +48,9 @@ class ConnectToAdminNode(Resource):
 new_node_model = node_ns.model(
     "New Node",
     {
+        BLOCKCHAIN_NAME_FIELD_NAME: fields.String(
+            required=True, description="The blockchain name"
+        ),
         NEW_NODE_ADDRESS_FIELD_NAME: fields.String(
             required=True, description="New node address"
         )
@@ -68,13 +72,18 @@ class AddNode(Resource):
         Adds the provided node to the blockchain network
         """
         new_node_address = node_ns.payload[NEW_NODE_ADDRESS_FIELD_NAME]
+        blockchain_name = node_ns.payload[BLOCKCHAIN_NAME_FIELD_NAME]
+
+        if not blockchain_name or not blockchain_name.strip():
+            raise ValueError("The blockchain name can't be empty!")
 
         if not new_node_address or not new_node_address.strip():
             raise ValueError("The new node adddress can't be empty!")
 
         new_node_wallet_address = new_node_address.strip()
+        blockchain_name = blockchain_name.strip()
         return (
-            {"walletAddress": NodeController.add_node(new_node_wallet_address)},
+            {"walletAddress": NodeController.add_node(blockchain_name, new_node_wallet_address)},
             status.HTTP_200_OK,
         )
 

--- a/app/models/node/node_controller.py
+++ b/app/models/node/node_controller.py
@@ -10,7 +10,7 @@ class NodeController:
     GRANT_ARG = ["grant"]
 
     @staticmethod
-    def connect_to_admin_node(blockchain_name: str,admin_node_address: str):
+    def connect_to_admin_node(admin_node_address: str):
         """
         Initializes the connection between the current node and the admin
         :param admin_node_address: Node address of the admin node


### PR DESCRIPTION
The node controller has two key methods:
The connect_to_admin_node and the add_node.

The connect_to_admin_node was requiringa blockchain name which shouldn't be the case because at this point we don't know the blockchain name. This parameter was removed from the controller and the end point was fixed as a result.

The add_node requires blockchain name so that it can add the new node to the right blockchain. The node end point was not passing the blockchain name to the controller. This is now fixed.